### PR TITLE
Make table names configurable via environment variables

### DIFF
--- a/service_type_generator/README.md
+++ b/service_type_generator/README.md
@@ -46,18 +46,21 @@ your_project/
 ```bash
 pip install -r requirements.txt
 
-### 2. Configure Credentials
-Set the path to your Google Cloud service account key in config.py. Do not commit the credential file to version control.
+### 2. Configure Environment
+Set the following environment variables before running the script:
 
+- `GOOGLE_APPLICATION_CREDENTIALS` - path to your service account key
+- `BQ_OUTPUT_TABLE` - BigQuery table for the full results (default: `kulti_test.full_service_type_logic`)
+- `ASK_CLIENT_TABLE` - table for the AskClient subset (default: `kulti_test.ask_client_flags`)
 
 ### 3. Run the Script
 
 python main.py
 
 Outputs
-Full logic results to: kulti_test.full_service_type_logic
+Full logic results to: value of `BQ_OUTPUT_TABLE`
 
-Filtered AskClient results to: kulti_test.ask_client_flags
+Filtered AskClient results to: value of `ASK_CLIENT_TABLE`
 
 Excel exports: final_df.xlsx, askclient_final.xlsx
 

--- a/service_type_generator/config.py
+++ b/service_type_generator/config.py
@@ -1,10 +1,17 @@
 import os
 from google.cloud import bigquery
 
-# Point to your service account key
-os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = r"PATH-TO-JSON"
+# Optionally point to a service account key via environment variable
+GOOGLE_APPLICATION_CREDENTIALS = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+if GOOGLE_APPLICATION_CREDENTIALS:
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = GOOGLE_APPLICATION_CREDENTIALS
 
-BQ_OUTPUT_TABLE = "kulti_test.full_service_type_logic"
+# BigQuery table names can be overridden with environment variables
+BQ_OUTPUT_TABLE = os.getenv("BQ_OUTPUT_TABLE", "kulti_test.full_service_type_logic")
+ASK_CLIENT_TABLE = os.getenv("ASK_CLIENT_TABLE", "kulti_test.ask_client_flags")
+SERVICE_TYPES_TABLE = os.getenv("SERVICE_TYPES_TABLE", "kulti_test.kulti_service_types")
+MERGED_APPOINTMENT_TABLE = os.getenv("MERGED_APPOINTMENT_TABLE", "transformation_layer.merged_appointment")
+MERGED_SUBSCRIPTION_TABLE = os.getenv("MERGED_SUBSCRIPTION_TABLE", "transformation_layer.merged_subscription")
 
 BQ_OUTPUT_SCHEMA = [
     bigquery.SchemaField("TYPE_ID", "INT64"),

--- a/service_type_generator/data_fetching/appointments.py
+++ b/service_type_generator/data_fetching/appointments.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from config import MERGED_APPOINTMENT_TABLE
 
 def get_appointments_for_client(bq_client, client_id):
     query = f"""
@@ -7,7 +8,7 @@ def get_appointments_for_client(bq_client, client_id):
             type,
             appointmentDate,
             clientID
-        FROM `transformation_layer.merged_appointment`
+        FROM `{MERGED_APPOINTMENT_TABLE}`
         WHERE clientID = '{client_id}'
     """
     print(f"Fetching appointments for client: {client_id}")

--- a/service_type_generator/data_fetching/clients.py
+++ b/service_type_generator/data_fetching/clients.py
@@ -1,7 +1,10 @@
+from config import SERVICE_TYPES_TABLE
+
+
 def get_distinct_clients(bq_client):
-    query = """
+    query = f"""
         SELECT DISTINCT CLIENT AS clientId
-        FROM `kulti_test.kulti_service_types`
+        FROM `{SERVICE_TYPES_TABLE}`
         WHERE CLIENT IS NOT NULL
     """
     print("Fetching distinct clients...")

--- a/service_type_generator/data_fetching/service_types.py
+++ b/service_type_generator/data_fetching/service_types.py
@@ -1,3 +1,6 @@
+from config import SERVICE_TYPES_TABLE
+
+
 def get_service_types_for_client(bq_client, client_id):
     query = f"""
         SELECT
@@ -8,7 +11,7 @@ def get_service_types_for_client(bq_client, client_id):
             SAFE_CAST(FREQUENCY AS INT64) as API_FREQUENCY,
             SAFE_CAST(DEFAULT_LENGTH AS INT64) as API_DEFAULT_LENGTH,
             CLIENT as clientId
-        FROM `kulti_test.kulti_service_types`
+        FROM `{SERVICE_TYPES_TABLE}`
         WHERE CLIENT = '{client_id}'
     """
     print(f"Fetching service types for client: {client_id}")

--- a/service_type_generator/data_fetching/subscriptions.py
+++ b/service_type_generator/data_fetching/subscriptions.py
@@ -1,3 +1,6 @@
+from config import MERGED_SUBSCRIPTION_TABLE
+
+
 def get_subscriptions_for_client(bq_client, client_id):
     query = f"""
         SELECT
@@ -8,7 +11,7 @@ def get_subscriptions_for_client(bq_client, client_id):
             dateCancelled,
             clientID,
             dateAdded
-        FROM `transformation_layer.merged_subscription`
+        FROM `{MERGED_SUBSCRIPTION_TABLE}`
         WHERE clientID = '{client_id}'
     """
     print(f"Fetching subscriptions for client: {client_id}")

--- a/service_type_generator/output/exporter.py
+++ b/service_type_generator/output/exporter.py
@@ -1,5 +1,6 @@
 from google.cloud import bigquery
 import pandas as pd
+from config import ASK_CLIENT_TABLE
 
 def export_askclient_table(final_df):
     print("Exporting AskClient rows to BigQuery...")
@@ -38,7 +39,7 @@ def export_askclient_table(final_df):
 
     # Upload to BQ
     bq_client = bigquery.Client()
-    table_id = "kulti_test.ask_client_flags"
+    table_id = ASK_CLIENT_TABLE
 
     job_config = bigquery.LoadJobConfig(
         write_disposition="WRITE_TRUNCATE",


### PR DESCRIPTION
## Summary
- use env vars in `config.py` for credential path and all BigQuery table names
- update fetch modules to read table constants from config
- export AskClient table using configurable name
- document environment variables in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d5946f2188324b7553cd9491727ec