### PR TITLE
Parameterize dataset IDs via environment variables

### DIFF
--- a/service_type_generator/README.md
+++ b/service_type_generator/README.md
@@ -50,8 +50,10 @@ pip install -r requirements.txt
 Set the following environment variables before running the script:
 
 - `GOOGLE_APPLICATION_CREDENTIALS` - path to your service account key
-- `BQ_OUTPUT_TABLE` - BigQuery table for the full results (default: `kulti_test.full_service_type_logic`)
-- `ASK_CLIENT_TABLE` - table for the AskClient subset (default: `kulti_test.ask_client_flags`)
+- `DATASET_ID` - dataset containing service and output tables (default: `kulti_test`)
+- `TRANSFORMATION_DATASET_ID` - dataset for appointment/subscription tables (default: `transformation_layer`)
+- `BQ_OUTPUT_TABLE` - full results table (defaults to `DATASET_ID.full_service_type_logic`)
+- `ASK_CLIENT_TABLE` - AskClient subset table (defaults to `DATASET_ID.ask_client_flags`)
 
 ### 3. Run the Script
 

--- a/service_type_generator/config.py
+++ b/service_type_generator/config.py
@@ -6,12 +6,17 @@ GOOGLE_APPLICATION_CREDENTIALS = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
 if GOOGLE_APPLICATION_CREDENTIALS:
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = GOOGLE_APPLICATION_CREDENTIALS
 
-# BigQuery table names can be overridden with environment variables
-BQ_OUTPUT_TABLE = os.getenv("BQ_OUTPUT_TABLE", "kulti_test.full_service_type_logic")
-ASK_CLIENT_TABLE = os.getenv("ASK_CLIENT_TABLE", "kulti_test.ask_client_flags")
-SERVICE_TYPES_TABLE = os.getenv("SERVICE_TYPES_TABLE", "kulti_test.kulti_service_types")
-MERGED_APPOINTMENT_TABLE = os.getenv("MERGED_APPOINTMENT_TABLE", "transformation_layer.merged_appointment")
-MERGED_SUBSCRIPTION_TABLE = os.getenv("MERGED_SUBSCRIPTION_TABLE", "transformation_layer.merged_subscription")
+# Dataset IDs can be customized via environment variables
+DATASET_ID = os.getenv("DATASET_ID", "kulti_test")
+TRANSFORMATION_DATASET_ID = os.getenv("TRANSFORMATION_DATASET_ID", "transformation_layer")
+
+# BigQuery table names can be overridden with environment variables. They default
+# to the dataset IDs above combined with the table names used in development.
+BQ_OUTPUT_TABLE = os.getenv("BQ_OUTPUT_TABLE", f"{DATASET_ID}.full_service_type_logic")
+ASK_CLIENT_TABLE = os.getenv("ASK_CLIENT_TABLE", f"{DATASET_ID}.ask_client_flags")
+SERVICE_TYPES_TABLE = os.getenv("SERVICE_TYPES_TABLE", f"{DATASET_ID}.kulti_service_types")
+MERGED_APPOINTMENT_TABLE = os.getenv("MERGED_APPOINTMENT_TABLE", f"{TRANSFORMATION_DATASET_ID}.merged_appointment")
+MERGED_SUBSCRIPTION_TABLE = os.getenv("MERGED_SUBSCRIPTION_TABLE", f"{TRANSFORMATION_DATASET_ID}.merged_subscription")
 
 BQ_OUTPUT_SCHEMA = [
     bigquery.SchemaField("TYPE_ID", "INT64"),

--- a/service_type_generator/data_fetching/clients.py
+++ b/service_type_generator/data_fetching/clients.py
@@ -1,4 +1,12 @@
-from config import SERVICE_TYPES_TABLE
+import os
+
+# Table ID can be overridden with environment variables. It defaults to the
+# DATASET_ID defined in config combined with the service types table name.
+from config import DATASET_ID
+
+SERVICE_TYPES_TABLE = os.getenv(
+    "SERVICE_TYPES_TABLE", f"{DATASET_ID}.kulti_service_types"
+)
 
 
 def get_distinct_clients(bq_client):

--- a/service_type_generator/data_fetching/service_types.py
+++ b/service_type_generator/data_fetching/service_types.py
@@ -1,4 +1,9 @@
-from config import SERVICE_TYPES_TABLE
+import os
+from config import DATASET_ID
+
+SERVICE_TYPES_TABLE = os.getenv(
+    "SERVICE_TYPES_TABLE", f"{DATASET_ID}.kulti_service_types"
+)
 
 
 def get_service_types_for_client(bq_client, client_id):

--- a/service_type_generator/output/exporter.py
+++ b/service_type_generator/output/exporter.py
@@ -1,6 +1,11 @@
 from google.cloud import bigquery
 import pandas as pd
-from config import ASK_CLIENT_TABLE
+import os
+from config import DATASET_ID
+
+ASK_CLIENT_TABLE = os.getenv(
+    "ASK_CLIENT_TABLE", f"{DATASET_ID}.ask_client_flags"
+)
 
 def export_askclient_table(final_df):
     print("Exporting AskClient rows to BigQuery...")


### PR DESCRIPTION
## Summary
- add dataset-specific environment variables to `config.py`
- pull dataset table IDs from the environment in `clients.py`, `service_types.py`, and `exporter.py`
- document new variables in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685d5b7bf2188324b5d3c08ea5aff926