### PR TITLE
Filter rows by active subscription

### DIFF
--- a/service_type_generator/main.py
+++ b/service_type_generator/main.py
@@ -8,6 +8,7 @@ from data_fetching.appointments import get_appointments_for_client
 from data_fetching.subscriptions import get_subscriptions_for_client
 from processing.analyzer import analyze_service_type
 from processing.builder import build_final_dataframe
+from processing.filters import filter_active_subscription
 from output.exporter import export_askclient_table
 from output.uploader import upload_to_bigquery
 from config import BQ_OUTPUT_TABLE, BQ_OUTPUT_SCHEMA
@@ -67,6 +68,9 @@ def main():
             all_rows.append(result_row)
 
     final_df = build_final_dataframe(all_rows)
+    # Filter to rows with an active subscription before exporting
+    final_df = filter_active_subscription(final_df)
+
     export_askclient_table(final_df)
     upload_to_bigquery(final_df, BQ_OUTPUT_TABLE, BQ_OUTPUT_SCHEMA)
     final_df.to_excel("final_df.xlsx", index=False)

--- a/service_type_generator/processing/filters.py
+++ b/service_type_generator/processing/filters.py
@@ -1,0 +1,5 @@
+import pandas as pd
+
+def filter_active_subscription(df: pd.DataFrame) -> pd.DataFrame:
+    """Return only rows with an active subscription."""
+    return df[df["hasActiveSubscription"]]


### PR DESCRIPTION
## Summary
- add a processing filter for active subscriptions
- filter results in `main.py` before export

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68641220d648832495a8bbf184667d46