### PR TITLE
Add Google Sheets export option

### DIFF
--- a/service_type_generator/config.py
+++ b/service_type_generator/config.py
@@ -19,6 +19,9 @@ MERGED_APPOINTMENT_TABLE = os.getenv("MERGED_APPOINTMENT_TABLE", f"{TRANSFORMATI
 MERGED_SUBSCRIPTION_TABLE = os.getenv("MERGED_SUBSCRIPTION_TABLE", f"{TRANSFORMATION_DATASET_ID}.merged_subscription")
 MERGED_SERVICE_TYPE_TABLE = os.getenv("MERGED_SERVICE_TYPE_TABLE", f"{TRANSFORMATION_DATASET_ID}.merged_service_type")
 
+# Optional Google Sheet ID for exporting results
+GOOGLE_SHEET_ID = os.getenv("GOOGLE_SHEET_ID")
+
 BQ_OUTPUT_SCHEMA = [
     bigquery.SchemaField("TYPE_ID", "INT64"),
     bigquery.SchemaField("DESCRIPTION", "STRING"),

--- a/service_type_generator/main.py
+++ b/service_type_generator/main.py
@@ -11,7 +11,8 @@ from processing.builder import build_final_dataframe
 from processing.filters import filter_active_subscription
 from output.exporter import export_askclient_table
 from output.uploader import upload_to_bigquery
-from config import BQ_OUTPUT_TABLE, BQ_OUTPUT_SCHEMA
+from output.google_sheets import export_to_google_sheets
+from config import BQ_OUTPUT_TABLE, BQ_OUTPUT_SCHEMA, GOOGLE_SHEET_ID
 import argparse
 import os
 import pandas as pd
@@ -73,6 +74,8 @@ def main():
 
     export_askclient_table(final_df)
     upload_to_bigquery(final_df, BQ_OUTPUT_TABLE, BQ_OUTPUT_SCHEMA)
+    if GOOGLE_SHEET_ID:
+        export_to_google_sheets(final_df, GOOGLE_SHEET_ID)
     final_df.to_excel("final_df.xlsx", index=False)
     print("Done.")
 

--- a/service_type_generator/output/google_sheets.py
+++ b/service_type_generator/output/google_sheets.py
@@ -1,0 +1,27 @@
+import os
+import gspread
+from gspread_dataframe import set_with_dataframe
+from google.oauth2 import service_account
+
+
+def export_to_google_sheets(df, sheet_id, worksheet="Sheet1"):
+    """Export a DataFrame to a Google Sheet using a service account."""
+    credentials_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+    if not credentials_path:
+        raise ValueError("GOOGLE_APPLICATION_CREDENTIALS not set")
+
+    scopes = ["https://www.googleapis.com/auth/spreadsheets"]
+    creds = service_account.Credentials.from_service_account_file(
+        credentials_path, scopes=scopes
+    )
+    client = gspread.authorize(creds)
+
+    sheet = client.open_by_key(sheet_id)
+    try:
+        ws = sheet.worksheet(worksheet)
+    except gspread.WorksheetNotFound:
+        ws = sheet.add_worksheet(title=worksheet, rows="100", cols="20")
+
+    ws.clear()
+    set_with_dataframe(ws, df, include_index=False, resize=True)
+

--- a/service_type_generator/requirements.txt
+++ b/service_type_generator/requirements.txt
@@ -1,3 +1,6 @@
 pandas>=1.3.0
 google-cloud-bigquery>=3.5.0
 openpyxl>=3.0.10
+
+gspread>=5.0.0
+gspread_dataframe>=3.2.2


### PR DESCRIPTION
## Summary
- add optional Google Sheet export through `export_to_google_sheets`
- support `GOOGLE_SHEET_ID` configuration
- call exporter from `main.py` when env var is set
- include gspread libraries

## Testing
- `python -m py_compile service_type_generator/output/google_sheets.py service_type_generator/main.py service_type_generator/config.py`

------
https://chatgpt.com/codex/tasks/task_e_68641e1aa4a883248372e3c89dbb0cb9