### PR TITLE
Add Google Sheets export option

### DIFF
--- a/service_type_generator/README.md
+++ b/service_type_generator/README.md
@@ -51,6 +51,7 @@ pip install -r requirements.txt
 Set the following environment variables before running the script:
 
 - `GOOGLE_APPLICATION_CREDENTIALS` - path to your service account key
+- `GOOGLE_SHEETS_FOLDER_ID` - optional Drive folder for exporting per-client Google Sheets
 - `DATASET_ID` - dataset containing service and output tables (default: `kulti_test`)
 - `TRANSFORMATION_DATASET_ID` - dataset for appointment/subscription tables (default: `transformation_layer`)
 - `BQ_OUTPUT_TABLE` - full results table (defaults to `DATASET_ID.full_service_type_logic`)
@@ -67,6 +68,7 @@ Full logic results to: value of `BQ_OUTPUT_TABLE`
 Filtered AskClient results to: value of `ASK_CLIENT_TABLE`
 
 Excel exports: final_df.xlsx, askclient_final.xlsx
+Per-client Google Sheets: created or updated in the folder set by `GOOGLE_SHEETS_FOLDER_ID`
 
 Notes
 String matching is used for detecting word signals.

--- a/service_type_generator/config.py
+++ b/service_type_generator/config.py
@@ -19,6 +19,9 @@ MERGED_APPOINTMENT_TABLE = os.getenv("MERGED_APPOINTMENT_TABLE", f"{TRANSFORMATI
 MERGED_SUBSCRIPTION_TABLE = os.getenv("MERGED_SUBSCRIPTION_TABLE", f"{TRANSFORMATION_DATASET_ID}.merged_subscription")
 MERGED_SERVICE_TYPE_TABLE = os.getenv("MERGED_SERVICE_TYPE_TABLE", f"{TRANSFORMATION_DATASET_ID}.merged_service_type")
 
+# Optional Google Drive folder ID for exporting per-client sheets
+GOOGLE_SHEETS_FOLDER_ID = os.getenv("GOOGLE_SHEETS_FOLDER_ID")
+
 BQ_OUTPUT_SCHEMA = [
     bigquery.SchemaField("TYPE_ID", "INT64"),
     bigquery.SchemaField("DESCRIPTION", "STRING"),

--- a/service_type_generator/main.py
+++ b/service_type_generator/main.py
@@ -11,7 +11,8 @@ from processing.builder import build_final_dataframe
 from processing.filters import filter_active_subscription
 from output.exporter import export_askclient_table
 from output.uploader import upload_to_bigquery
-from config import BQ_OUTPUT_TABLE, BQ_OUTPUT_SCHEMA
+from output.google_sheets import export_to_google_sheets
+from config import BQ_OUTPUT_TABLE, BQ_OUTPUT_SCHEMA, GOOGLE_SHEETS_FOLDER_ID
 import argparse
 import os
 import pandas as pd
@@ -73,6 +74,8 @@ def main():
 
     export_askclient_table(final_df)
     upload_to_bigquery(final_df, BQ_OUTPUT_TABLE, BQ_OUTPUT_SCHEMA)
+    if GOOGLE_SHEETS_FOLDER_ID:
+        export_to_google_sheets(final_df, GOOGLE_SHEETS_FOLDER_ID)
     final_df.to_excel("final_df.xlsx", index=False)
     print("Done.")
 

--- a/service_type_generator/output/google_sheets.py
+++ b/service_type_generator/output/google_sheets.py
@@ -1,0 +1,47 @@
+import os
+import gspread
+from gspread_dataframe import set_with_dataframe
+from google.oauth2 import service_account
+
+
+def export_to_google_sheets(df, folder_id, worksheet="Sheet1"):
+    """Export each client's data to a sheet inside the given Drive folder.
+
+    If a spreadsheet already exists for a client (named after the client ID)
+    it will be updated. Otherwise a new spreadsheet will be created in the
+    specified folder.
+    """
+    credentials_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+    if not credentials_path:
+        raise ValueError("GOOGLE_APPLICATION_CREDENTIALS not set")
+
+    scopes = [
+        "https://www.googleapis.com/auth/drive",
+        "https://www.googleapis.com/auth/spreadsheets",
+    ]
+    creds = service_account.Credentials.from_service_account_file(
+        credentials_path, scopes=scopes
+    )
+    client = gspread.authorize(creds)
+
+    # Cache existing files in the folder to avoid extra API calls
+    existing_files = {
+        f["name"]: f
+        for f in client.list_spreadsheet_files(parent_id=folder_id)
+    }
+
+    for client_id, client_df in df.groupby("Client"):
+        title = str(client_id)
+        if title in existing_files:
+            sheet = client.open_by_key(existing_files[title]["id"])
+        else:
+            sheet = client.create(title, folder_id=folder_id)
+
+        try:
+            ws = sheet.worksheet(worksheet)
+        except gspread.WorksheetNotFound:
+            ws = sheet.add_worksheet(title=worksheet, rows="100", cols="20")
+
+        ws.clear()
+        set_with_dataframe(ws, client_df, include_index=False, resize=True)
+

--- a/service_type_generator/requirements.txt
+++ b/service_type_generator/requirements.txt
@@ -1,3 +1,6 @@
 pandas>=1.3.0
 google-cloud-bigquery>=3.5.0
 openpyxl>=3.0.10
+
+gspread>=5.0.0
+gspread_dataframe>=3.2.2


### PR DESCRIPTION
## Summary
- add optional Google Sheet export through `export_to_google_sheets`
- support `GOOGLE_SHEETS_FOLDER_ID` configuration
- call exporter from `main.py` when env var is set
- include gspread libraries

## Testing
- `python -m py_compile output/google_sheets.py main.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_68641e1aa4a883248372e3c89dbb0cb9