### PR TITLE
Switch to FR_SERVICE_TYPE in raw layer

### DIFF
--- a/service_type_generator/config.py
+++ b/service_type_generator/config.py
@@ -15,7 +15,9 @@ TRANSFORMATION_DATASET_ID = os.getenv("TRANSFORMATION_DATASET_ID", "transformati
 # to the dataset IDs above combined with the table names used in development.
 BQ_OUTPUT_TABLE = os.getenv("BQ_OUTPUT_TABLE", f"{DATASET_ID}.full_service_type_logic")
 ASK_CLIENT_TABLE = os.getenv("ASK_CLIENT_TABLE", f"{DATASET_ID}.ask_client_flags")
-SERVICE_TYPES_TABLE = os.getenv("SERVICE_TYPES_TABLE", f"{DATASET_ID}.kulti_service_types")
+SERVICE_TYPES_TABLE = os.getenv(
+    "SERVICE_TYPES_TABLE", f"{RAW_DATASET_ID}.FR_SERVICE_TYPE"
+)
 MERGED_APPOINTMENT_TABLE = os.getenv("MERGED_APPOINTMENT_TABLE", f"{TRANSFORMATION_DATASET_ID}.merged_appointment")
 MERGED_SUBSCRIPTION_TABLE = os.getenv("MERGED_SUBSCRIPTION_TABLE", f"{TRANSFORMATION_DATASET_ID}.merged_subscription")
 MERGED_SERVICE_TYPE_TABLE = os.getenv("MERGED_SERVICE_TYPE_TABLE", f"{TRANSFORMATION_DATASET_ID}.merged_service_type")

--- a/service_type_generator/data_fetching/clients.py
+++ b/service_type_generator/data_fetching/clients.py
@@ -2,13 +2,13 @@ import os
 
 # Table ID can be overridden with environment variables. It defaults to the
 # DATASET_ID defined in config combined with the service types table name.
-from config import DATASET_ID
+from config import RAW_DATASET_ID
 from utils.logger import Logger
 
 logger = Logger(__name__)
 
 SERVICE_TYPES_TABLE = os.getenv(
-    "SERVICE_TYPES_TABLE", f"{DATASET_ID}.kulti_service_types"
+    "SERVICE_TYPES_TABLE", f"{RAW_DATASET_ID}.FR_SERVICE_TYPE"
 )
 
 

--- a/service_type_generator/data_fetching/service_types.py
+++ b/service_type_generator/data_fetching/service_types.py
@@ -1,26 +1,34 @@
 import os
-from config import DATASET_ID, MERGED_SERVICE_TYPE_TABLE
+from config import RAW_DATASET_ID, MERGED_SERVICE_TYPE_TABLE
 from utils.logger import Logger
 
 logger = Logger(__name__)
 
 SERVICE_TYPES_TABLE = os.getenv(
-    "SERVICE_TYPES_TABLE", f"{DATASET_ID}.kulti_service_types"
+    "SERVICE_TYPES_TABLE", f"{RAW_DATASET_ID}.FR_SERVICE_TYPE"
 )
 
 
 def get_service_types_for_client(bq_client, client_id):
     query = f"""
         SELECT
-            CAST(TYPE_ID as INT64) as TYPE_ID,
+            CAST(TYPE_ID AS INT64) AS TYPE_ID,
             DESCRIPTION,
-            SAFE_CAST(RESERVICE AS INT64) as API_RESERVICE,
-            SAFE_CAST(REGULAR_SERVICE AS INT64) as API_REGULAR_SERVICE,
-            SAFE_CAST(FREQUENCY AS INT64) as API_FREQUENCY,
-            SAFE_CAST(DEFAULT_LENGTH AS INT64) as API_DEFAULT_LENGTH,
-            CLIENT as clientId
-        FROM `{SERVICE_TYPES_TABLE}`
-        WHERE CLIENT = '{client_id}'
+            SAFE_CAST(RESERVICE AS INT64) AS API_RESERVICE,
+            SAFE_CAST(REGULAR_SERVICE AS INT64) AS API_REGULAR_SERVICE,
+            SAFE_CAST(FREQUENCY AS INT64) AS API_FREQUENCY,
+            SAFE_CAST(DEFAULT_LENGTH AS INT64) AS API_DEFAULT_LENGTH,
+            CLIENT AS clientId
+        FROM (
+            SELECT *,
+                ROW_NUMBER() OVER (
+                    PARTITION BY CLIENT, TYPE_ID
+                    ORDER BY PARSE_TIMESTAMP('%Y-%m-%d %H:%M:%S', DATE_LOADED) DESC
+                ) AS rn
+            FROM `{SERVICE_TYPES_TABLE}`
+            WHERE CLIENT = '{client_id}'
+        )
+        WHERE rn = 1
     """
     logger.info(f"Fetching service types for client: {client_id}")
     return bq_client.query(query).to_dataframe()


### PR DESCRIPTION
## Summary
- point `SERVICE_TYPES_TABLE` to `raw_layer.FR_SERVICE_TYPE`
- update distinct client query to use raw layer
- adjust service type retrieval queries to reference raw layer

## Testing
- `python -m py_compile service_type_generator/**/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688378fd866083249a123b4ffda722ef